### PR TITLE
feat: add shared package for common utilities and update dependencies…

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,6 +30,7 @@
         "db:fresh": "npm run db:clear && npm run db:seed"
     },
     "dependencies": {
+        "@homerunnie/shared": "workspace:*",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,6 +22,7 @@
     ]
   },
   "dependencies": {
+    "@homerunnie/shared": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-radio-group": "^1.3.8",

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,26 @@
+# @homerunnie/shared
+
+Homerunnie 모노레포의 공유 패키지입니다. CommonJS와 ES Module을 동시에 지원하는 듀얼 패키지 시스템을 사용합니다.
+
+## 빌드
+
+```bash
+pnpm build
+```
+
+## 사용법
+
+### Backend (NestJS - CommonJS)
+
+```typescript
+import { formatDate, validateEmail } from '@homerunnie/shared';
+```
+
+### Frontend (Next.js - ESM)
+
+```typescript
+import { formatDate, validateEmail } from '@homerunnie/shared';
+```
+
+두 환경 모두 동일한 import 문을 사용할 수 있으며, 패키지 시스템이 자동으로 적절한 형식(CJS 또는 ESM)을 선택합니다.
+

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@homerunnie/shared",
+  "version": "0.0.1",
+  "description": "Shared package for homerunnie monorepo",
+  "private": true,
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm clean && rollup -c && tsc --emitDeclarationOnly --declaration --declarationMap",
+    "dev": "rollup -c --watch",
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.1.1",
+    "@types/node": "^22.10.7",
+    "rollup": "^4.28.1",
+    "typescript": "^5.7.3"
+  }
+}
+

--- a/packages/shared/rollup.config.js
+++ b/packages/shared/rollup.config.js
@@ -1,0 +1,51 @@
+import typescript from '@rollup/plugin-typescript';
+
+export default [
+  // CommonJS 빌드
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/cjs/index.js',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true,
+    },
+    plugins: [
+      typescript({
+        declaration: false,
+        declarationMap: false,
+        sourceMap: true,
+        rootDir: './src',
+        exclude: ['**/*.test.ts', '**/*.spec.ts'],
+        tsconfig: false, // tsconfig.json 사용 안 함
+      }),
+    ],
+    external: (id) => {
+      // node_modules와 절대 경로는 external로 처리
+      return !id.startsWith('.') && !id.startsWith('/');
+    },
+  },
+  // ES Module 빌드
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/esm/index.js',
+      format: 'es',
+      sourcemap: true,
+    },
+    plugins: [
+      typescript({
+        declaration: false,
+        declarationMap: false,
+        sourceMap: true,
+        rootDir: './src',
+        exclude: ['**/*.test.ts', '**/*.spec.ts'],
+        tsconfig: false, // tsconfig.json 사용 안 함
+      }),
+    ],
+    external: (id) => {
+      return !id.startsWith('.') && !id.startsWith('/');
+    },
+  },
+];
+

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,23 @@
+// 공유 유틸리티 함수 예시
+export const formatDate = (date: Date): string => {
+  return date.toISOString().split('T')[0];
+};
+
+export const validateEmail = (email: string): boolean => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
+// 타입 정의 예시
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+// 상수 예시
+export const API_ENDPOINTS = {
+  AUTH: '/api/auth',
+  USERS: '/api/users',
+} as const;
+

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/backend:
     dependencies:
+      '@homerunnie/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -171,6 +174,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@homerunnie/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -325,6 +331,21 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@20.19.26)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/shared:
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.1
+        version: 12.3.0(rollup@4.53.3)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.2
+      rollup:
+        specifier: ^4.28.1
+        version: 4.53.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
 packages:
 
@@ -2918,6 +2939,28 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/plugin-typescript@12.3.0':
+    resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.53.3':
     resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
     cpu: [arm]
@@ -5231,6 +5274,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -11046,6 +11092,23 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/plugin-typescript@12.3.0(rollup@4.53.3)(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
+      resolve: 1.22.11
+      typescript: 5.9.3
+    optionalDependencies:
+      rollup: 4.53.3
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.53.3)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.53.3
+
   '@rollup/rollup-android-arm-eabi@4.53.3':
     optional: true
 
@@ -13788,6 +13851,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -14908,7 +14973,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.26
+      '@types/node': 22.19.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

### 듀얼 패키지 시스템 구현

모노레포에서 Backend(NestJS - CommonJS)와 Frontend(Next.js - ES Module) 간 공유 코드를 사용하기 위해 `@homerunnie/shared` 패키지를 추가했습니다.

#### 주요 변경사항

1. **Shared 패키지 생성** (`packages/shared/`)
   - Rollup을 사용한 듀얼 패키지 빌드 설정
   - CommonJS(`dist/cjs/`)와 ES Module(`dist/esm/`) 동시 지원
   - TypeScript 타입 정의 자동 생성 (`dist/types/`)
   - `package.json`의 `exports` 필드를 통한 조건부 export 설정

2. **의존성 추가**
   - `apps/backend/package.json`: `@homerunnie/shared` 의존성 추가
   - `apps/frontend/package.json`: `@homerunnie/shared` 의존성 추가

3. **빌드 설정**
   - Rollup 설정 파일 (`rollup.config.js`)
   - TypeScript 설정 파일 (`tsconfig.json`)
   - 빌드 스크립트: `pnpm build` (CJS/ESM 빌드 + 타입 정의 생성)

#### 기술 스택

- **Rollup**: 번들링 도구
- **@rollup/plugin-typescript**: TypeScript 지원
- **TypeScript**: 타입 정의 생성

#### 사용 방법

Backend와 Frontend 모두 동일한 import 문을 사용할 수 있으며, 각 환경에 맞는 형식이 자동으로 선택됩니다:
pescript
// Backend (NestJS - CommonJS)
import { formatDate, validateEmail } from '@homerunnie/shared';

// Frontend (Next.js - ESM)
import { formatDate, validateEmail } from '@homerunnie/shared';## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

- Shared 패키지는 현재 샘플 코드(`formatDate`, `validateEmail`, `ApiResponse` 등)를 포함하고 있습니다.
- 향후 Backend와 Frontend 간 공유가 필요한 유틸리티 함수, 타입, 상수 등을 이 패키지로 이동할 수 있습니다.
- 빌드 명령어: `cd packages/shared && pnpm build`