### PR TITLE
Fix: ChatJoinRequest 쿼리에서 deleted 컬럼 의존 제거

### DIFF
--- a/apps/backend/src/chat/repository/chat.repository.ts
+++ b/apps/backend/src/chat/repository/chat.repository.ts
@@ -200,7 +200,12 @@ export class ChatRepository {
         memberId,
         status: ChatJoinRequestStatus.PENDING,
       })
-      .returning();
+      .returning({
+        id: ChatJoinRequest.id,
+        status: ChatJoinRequest.status,
+        chatRoomId: ChatJoinRequest.chatRoomId,
+        memberId: ChatJoinRequest.memberId,
+      });
 
     return request;
   }
@@ -224,7 +229,6 @@ export class ChatRepository {
         and(
           eq(ChatJoinRequest.chatRoomId, chatRoomId),
           eq(ChatJoinRequest.status, ChatJoinRequestStatus.PENDING),
-          eq(ChatJoinRequest.deleted, false),
         ),
       )
       .orderBy(desc(ChatJoinRequest.createdAt));
@@ -234,7 +238,12 @@ export class ChatRepository {
 
   async findJoinRequestById(requestId: number) {
     const [request] = await this.db
-      .select()
+      .select({
+        id: ChatJoinRequest.id,
+        status: ChatJoinRequest.status,
+        chatRoomId: ChatJoinRequest.chatRoomId,
+        memberId: ChatJoinRequest.memberId,
+      })
       .from(ChatJoinRequest)
       .where(eq(ChatJoinRequest.id, requestId));
 
@@ -246,21 +255,28 @@ export class ChatRepository {
       .update(ChatJoinRequest)
       .set({ status })
       .where(eq(ChatJoinRequest.id, requestId))
-      .returning();
+      .returning({
+        id: ChatJoinRequest.id,
+        status: ChatJoinRequest.status,
+      });
 
     return updated || null;
   }
 
   async findExistingJoinRequest(chatRoomId: number, memberId: number) {
     const [request] = await this.db
-      .select()
+      .select({
+        id: ChatJoinRequest.id,
+        status: ChatJoinRequest.status,
+        chatRoomId: ChatJoinRequest.chatRoomId,
+        memberId: ChatJoinRequest.memberId,
+      })
       .from(ChatJoinRequest)
       .where(
         and(
           eq(ChatJoinRequest.chatRoomId, chatRoomId),
           eq(ChatJoinRequest.memberId, memberId),
           eq(ChatJoinRequest.status, ChatJoinRequestStatus.PENDING),
-          eq(ChatJoinRequest.deleted, false),
         ),
       );
 


### PR DESCRIPTION
- select()/returning()에서 명시적 컬럼 지정으로 DB 스키마 호환성 확보
- findPendingJoinRequests, findExistingJoinRequest에서 deleted 필터 제거
- 배포 DB에 deleted 컬럼이 없을 경우 발생하는 500 에러 방지

# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
