### PR TITLE
feat: SEO 기본 메타데이터 및 sitemap/robots 추가

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -6,9 +6,58 @@ import Header from '@/shared/ui/header/header';
 import Footer from '@/shared/ui/footer/footer';
 import '@/mocks'; // MSW 초기화 (브라우저 환경에서만 동작)
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.homerunnie.app';
+
 export const metadata: Metadata = {
-  title: 'Homerunnie',
-  description: '직관 메이트를 찾고 함께 응원하는 커뮤니티',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: 'Homerunnie | 직관 메이트 찾기',
+    template: '%s | Homerunnie',
+  },
+  description:
+    '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
+  keywords: ['야구', '직관', '메이트', 'KBO', '응원', '직관 메이트', '직관 모집', '야구 커뮤니티'],
+  applicationName: 'Homerunnie',
+  authors: [{ name: 'Homerunnie' }],
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: SITE_URL,
+    siteName: 'Homerunnie',
+    title: 'Homerunnie | 직관 메이트 찾기',
+    description:
+      '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
+    images: [
+      {
+        url: '/bg.png',
+        width: 1200,
+        height: 630,
+        alt: 'Homerunnie',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Homerunnie | 직관 메이트 찾기',
+    description: '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티',
+    images: ['/bg.png'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  icons: {
+    icon: '/icon.svg',
+  },
 };
 
 export default function RootLayout({

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -19,13 +19,9 @@ export const metadata: Metadata = {
   keywords: ['야구', '직관', '메이트', 'KBO', '응원', '직관 메이트', '직관 모집', '야구 커뮤니티'],
   applicationName: 'Homerunnie',
   authors: [{ name: 'Homerunnie' }],
-  alternates: {
-    canonical: '/',
-  },
   openGraph: {
     type: 'website',
     locale: 'ko_KR',
-    url: SITE_URL,
     siteName: 'Homerunnie',
     title: 'Homerunnie | 직관 메이트 찾기',
     description:

--- a/apps/frontend/src/app/robots.ts
+++ b/apps/frontend/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.homerunnie.app';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/chat', '/chat/', '/my', '/edit-profile', '/test-chat', '/api/'],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -18,17 +18,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'daily',
       priority: 0.9,
     },
-    {
-      url: `${SITE_URL}/login`,
-      lastModified: now,
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
-    {
-      url: `${SITE_URL}/signup`,
-      lastModified: now,
-      changeFrequency: 'yearly',
-      priority: 0.3,
-    },
   ];
 }

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.homerunnie.app';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/home`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/login`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/signup`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
- Root layout에 OG/Twitter/canonical/robots 등 메타데이터 확장
- app/sitemap.ts 생성 (정적 라우트 4개)
- app/robots.ts 생성 (비공개 라우트 disallow 처리)
- 사이트 URL은 NEXT_PUBLIC_SITE_URL 환경변수로 분리

# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
