### PR TITLE
fix: 루트 redirect를 308 영구 리디렉션으로 전환해 색인 오류 해결

### DIFF
--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/home',
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3030';
 

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/home');
-}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -7,16 +7,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: SITE_URL,
-      lastModified: now,
-      changeFrequency: 'daily',
-      priority: 1.0,
-    },
-    {
       url: `${SITE_URL}/home`,
       lastModified: now,
       changeFrequency: 'daily',
-      priority: 0.9,
+      priority: 1.0,
     },
   ];
 }


### PR DESCRIPTION
Vercel CDN이 RSC 응답을 일반 요청에도 캐시해 Location 헤더 없는
307이 노출됐고, Search Console에서 "리디렉션 오류"로 색인이
차단됐다. next.config의 redirects로 옮겨 엣지 레벨 308을 보장하고
sitemap에서 중복되는 루트 항목을 제거한다.

# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
