### PR TITLE
feat: 한글 브랜드명 SEO 최적화

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -11,34 +11,46 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.homerunnie.app
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: 'Homerunnie | 직관 메이트 찾기',
-    template: '%s | Homerunnie',
+    default: '홈러니(Homerunnie) | 직관 메이트 찾기',
+    template: '%s | 홈러니(Homerunnie)',
   },
   description:
-    '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
-  keywords: ['야구', '직관', '메이트', 'KBO', '응원', '직관 메이트', '직관 모집', '야구 커뮤니티'],
-  applicationName: 'Homerunnie',
-  authors: [{ name: 'Homerunnie' }],
+    '홈러니(Homerunnie)는 야구 직관 메이트를 찾고 함께 응원하는 커뮤니티입니다. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
+  keywords: [
+    '홈러니',
+    'Homerunnie',
+    '홈러니앱',
+    '야구',
+    '직관',
+    '메이트',
+    'KBO',
+    '응원',
+    '직관 메이트',
+    '직관 모집',
+    '야구 커뮤니티',
+  ],
+  applicationName: '홈러니(Homerunnie)',
+  authors: [{ name: '홈러니(Homerunnie)' }],
   openGraph: {
     type: 'website',
     locale: 'ko_KR',
-    siteName: 'Homerunnie',
-    title: 'Homerunnie | 직관 메이트 찾기',
+    siteName: '홈러니(Homerunnie)',
+    title: '홈러니(Homerunnie) | 직관 메이트 찾기',
     description:
-      '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
+      '홈러니(Homerunnie)는 야구 직관 메이트를 찾고 함께 응원하는 커뮤니티입니다. KBO 경기에 같이 갈 메이트를 모집하고 채팅으로 소통하세요.',
     images: [
       {
         url: '/bg.png',
         width: 1200,
         height: 630,
-        alt: 'Homerunnie',
+        alt: '홈러니(Homerunnie)',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Homerunnie | 직관 메이트 찾기',
-    description: '야구 직관 메이트를 찾고 함께 응원하는 커뮤니티',
+    title: '홈러니(Homerunnie) | 직관 메이트 찾기',
+    description: '홈러니는 야구 직관 메이트를 찾고 함께 응원하는 커뮤니티입니다.',
     images: ['/bg.png'],
   },
   robots: {
@@ -59,14 +71,39 @@ export const metadata: Metadata = {
   },
 };
 
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Homerunnie',
+  alternateName: ['홈러니', '홈러니앱'],
+  url: SITE_URL,
+};
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Homerunnie',
+  alternateName: ['홈러니', '홈러니앱'],
+  url: SITE_URL,
+  logo: `${SITE_URL}/icon.svg`,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <body className="font-sans bg-gray-50">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
         <Providers>
           <div className="min-h-screen flex flex-col">
             <Header />


### PR DESCRIPTION
- html lang을 en에서 ko로 변경해 한국어 검색 매칭 우선순위 확보
- 메타데이터 title/description/keywords/OG에 "홈러니" 병기
- WebSite/Organization JSON-LD에 alternateName으로 "홈러니" 등록해 Google이 영문/한글 브랜드명을 동일 엔티티로 학습하도록 유도

# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
