### PR TITLE
feat: 피드 게시글/댓글 수정·삭제 기능 추가

### DIFF
--- a/apps/backend/src/post/feed/comment/controller/feed-comment.controller.ts
+++ b/apps/backend/src/post/feed/comment/controller/feed-comment.controller.ts
@@ -5,11 +5,16 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import { FeedCommentService } from '@/post/feed/comment/service';
-import { CreateFeedCommentRequestDto, FeedCommentResponseDto } from '@/post/feed/comment/dto';
+import {
+  CreateFeedCommentRequestDto,
+  FeedCommentResponseDto,
+  UpdateFeedCommentRequestDto,
+} from '@/post/feed/comment/dto';
 import { CurrentMember } from '@/common';
 import { JwtAuthGuard } from '@/auth/guards';
 import {
@@ -17,6 +22,7 @@ import {
   DeleteFeedCommentSwagger,
   FeedCommentControllerSwagger,
   GetFeedCommentsSwagger,
+  UpdateFeedCommentSwagger,
 } from '@/post/feed/comment/swagger';
 
 @Controller('post/feed/:postId/comments')
@@ -41,6 +47,18 @@ export class FeedCommentController {
     @Body() dto: CreateFeedCommentRequestDto,
   ): Promise<FeedCommentResponseDto> {
     return this.feedCommentService.createComment(memberId, postId, dto);
+  }
+
+  @Patch(':commentId')
+  @UseGuards(JwtAuthGuard)
+  @UpdateFeedCommentSwagger
+  async updateComment(
+    @CurrentMember() memberId: number,
+    @Param('postId', ParseIntPipe) postId: number,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Body() dto: UpdateFeedCommentRequestDto,
+  ): Promise<FeedCommentResponseDto> {
+    return this.feedCommentService.updateComment(memberId, postId, commentId, dto);
   }
 
   @Delete(':commentId')

--- a/apps/backend/src/post/feed/comment/dto/index.ts
+++ b/apps/backend/src/post/feed/comment/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './request/create-feed-comment.request.dto';
+export * from './request/update-feed-comment.request.dto';
 export * from './response/feed-comment.response.dto';

--- a/apps/backend/src/post/feed/comment/dto/request/update-feed-comment.request.dto.ts
+++ b/apps/backend/src/post/feed/comment/dto/request/update-feed-comment.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateFeedCommentRequestDto {
+  @ApiProperty({
+    description: '수정할 댓글 본문',
+    example: '오타 수정했어요',
+    maxLength: 1000,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(1000)
+  content: string;
+}

--- a/apps/backend/src/post/feed/comment/repository/feed-comment.repository.ts
+++ b/apps/backend/src/post/feed/comment/repository/feed-comment.repository.ts
@@ -115,6 +115,13 @@ export class FeedCommentRepository {
       .where(eq(Comment.id, commentId));
   }
 
+  async updateCommentContent(commentId: number, content: string) {
+    await this.db
+      .update(Comment)
+      .set({ content, updatedAt: new Date() })
+      .where(eq(Comment.id, commentId));
+  }
+
   async countCommentsByPostIds(postIds: number[]): Promise<Record<number, number>> {
     if (postIds.length === 0) return {};
     const rows = await this.db

--- a/apps/backend/src/post/feed/comment/service/feed-comment.service.ts
+++ b/apps/backend/src/post/feed/comment/service/feed-comment.service.ts
@@ -6,7 +6,11 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { FeedCommentRepository, type FeedCommentQueryResult } from '@/post/feed/comment/repository';
-import { CreateFeedCommentRequestDto, FeedCommentResponseDto } from '@/post/feed/comment/dto';
+import {
+  CreateFeedCommentRequestDto,
+  FeedCommentResponseDto,
+  UpdateFeedCommentRequestDto,
+} from '@/post/feed/comment/dto';
 import { AuthorDto, AuthorType } from '@/post/shared/dto/author.dto';
 import { Team } from '@/common/enums';
 
@@ -84,6 +88,32 @@ export class FeedCommentService {
     }
 
     return Array.from(rootById.values());
+  }
+
+  async updateComment(
+    memberId: number,
+    postId: number,
+    commentId: number,
+    dto: UpdateFeedCommentRequestDto,
+  ): Promise<FeedCommentResponseDto> {
+    const comment = await this.feedCommentRepository.findCommentById(commentId);
+    if (!comment || comment.deleted) {
+      throw new NotFoundException('해당 댓글을 찾을 수 없습니다.');
+    }
+    if (comment.postId !== postId) {
+      throw new BadRequestException('댓글이 다른 게시글에 속해 있습니다.');
+    }
+    if (comment.authorId !== memberId) {
+      throw new ForbiddenException('작성자만 수정할 수 있습니다.');
+    }
+
+    await this.feedCommentRepository.updateCommentContent(commentId, dto.content);
+
+    const joined = await this.feedCommentRepository.findFeedCommentJoined(commentId);
+    if (!joined) {
+      throw new InternalServerErrorException('수정된 댓글 조회 실패');
+    }
+    return this.toResponse(joined);
   }
 
   async deleteComment(memberId: number, postId: number, commentId: number) {

--- a/apps/backend/src/post/feed/comment/swagger/index.ts
+++ b/apps/backend/src/post/feed/comment/swagger/index.ts
@@ -2,3 +2,4 @@ export * from './feed-comment-controller.swagger';
 export * from './create-feed-comment.swagger';
 export * from './get-feed-comments.swagger';
 export * from './delete-feed-comment.swagger';
+export * from './update-feed-comment.swagger';

--- a/apps/backend/src/post/feed/comment/swagger/update-feed-comment.swagger.ts
+++ b/apps/backend/src/post/feed/comment/swagger/update-feed-comment.swagger.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { FeedCommentResponseDto, UpdateFeedCommentRequestDto } from '@/post/feed/comment/dto';
+import { ErrorResponseDto } from '@/common';
+
+export const UpdateFeedCommentSwagger = applyDecorators(
+  ApiOperation({
+    summary: '피드 댓글 수정',
+    description: '작성자 본인만 수정 가능. content를 새 값으로 교체합니다.',
+  }),
+  ApiParam({ name: 'postId', type: Number, example: 1 }),
+  ApiParam({ name: 'commentId', type: Number, example: 10 }),
+  ApiBody({ type: UpdateFeedCommentRequestDto }),
+  ApiOkResponse({ type: FeedCommentResponseDto, description: '수정된 댓글' }),
+  ApiBadRequestResponse({ type: ErrorResponseDto, description: '댓글이 다른 게시글 소속 등' }),
+  ApiUnauthorizedResponse({ type: ErrorResponseDto, description: '인증되지 않은 사용자' }),
+  ApiForbiddenResponse({ type: ErrorResponseDto, description: '작성자가 아니어서 권한 없음' }),
+  ApiNotFoundResponse({ type: ErrorResponseDto, description: '댓글 없음' }),
+  ApiInternalServerErrorResponse({ type: ErrorResponseDto, description: '서버 내부 오류' }),
+);

--- a/apps/backend/src/post/feed/controller/feed.controller.ts
+++ b/apps/backend/src/post/feed/controller/feed.controller.ts
@@ -1,18 +1,32 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { FeedService } from '@/post/feed/service';
 import {
   CreateFeedPostRequestDto,
   FeedPostResponseDto,
   GetFeedPostsQueryDto,
   GetFeedPostsResponseDto,
+  UpdateFeedPostRequestDto,
 } from '@/post/feed/dto';
 import { CurrentMember, CurrentMemberOptional } from '@/common';
 import { JwtAuthGuard, OptionalJwtAuthGuard } from '@/auth/guards';
 import {
   CreateFeedPostSwagger,
+  DeleteFeedPostSwagger,
   GetFeedPostDetailSwagger,
   GetFeedPostsSwagger,
   FeedControllerSwagger,
+  UpdateFeedPostSwagger,
 } from '@/post/feed/swagger';
 
 @Controller('post/feed')
@@ -48,5 +62,26 @@ export class FeedController {
     @CurrentMemberOptional() viewerMemberId: number | null,
   ): Promise<FeedPostResponseDto> {
     return this.feedService.getFeedPostDetail(postId, viewerMemberId);
+  }
+
+  @Patch(':postId')
+  @UseGuards(JwtAuthGuard)
+  @UpdateFeedPostSwagger
+  async updateFeedPost(
+    @CurrentMember() memberId: number,
+    @Param('postId', ParseIntPipe) postId: number,
+    @Body() dto: UpdateFeedPostRequestDto,
+  ): Promise<FeedPostResponseDto> {
+    return this.feedService.updateFeedPost(memberId, postId, dto);
+  }
+
+  @Delete(':postId')
+  @UseGuards(JwtAuthGuard)
+  @DeleteFeedPostSwagger
+  async deleteFeedPost(
+    @CurrentMember() memberId: number,
+    @Param('postId', ParseIntPipe) postId: number,
+  ): Promise<{ id: number }> {
+    return this.feedService.deleteFeedPost(memberId, postId);
   }
 }

--- a/apps/backend/src/post/feed/dto/index.ts
+++ b/apps/backend/src/post/feed/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './request/create-feed-post.request.dto';
 export * from './request/get-feed-posts.query.dto';
+export * from './request/update-feed-post.request.dto';
 export * from './response/feed-post.response.dto';
 export * from './response/get-feed-posts.response.dto';

--- a/apps/backend/src/post/feed/dto/request/index.ts
+++ b/apps/backend/src/post/feed/dto/request/index.ts
@@ -1,2 +1,3 @@
 export * from './create-feed-post.request.dto';
 export * from './get-feed-posts.query.dto';
+export * from './update-feed-post.request.dto';

--- a/apps/backend/src/post/feed/dto/request/update-feed-post.request.dto.ts
+++ b/apps/backend/src/post/feed/dto/request/update-feed-post.request.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateFeedPostRequestDto {
+  @ApiPropertyOptional({
+    description: '본문 내용 (수정 시에만 전달)',
+    example: '오타 수정했어요!',
+    maxLength: 2000,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  content?: string;
+
+  @ApiPropertyOptional({
+    description:
+      '이미지 URL 배열 (전체 교체, 최대 4장). 빈 배열을 보내면 모든 이미지가 제거됩니다.',
+    type: [String],
+    example: ['https://cdn.example.com/img-1.jpg'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(4)
+  @IsString({ each: true })
+  @IsUrl({}, { each: true })
+  images?: string[];
+}

--- a/apps/backend/src/post/feed/dto/response/feed-post.response.dto.ts
+++ b/apps/backend/src/post/feed/dto/response/feed-post.response.dto.ts
@@ -33,6 +33,12 @@ export class FeedPostResponseDto {
   @ApiProperty({ description: '작성 시간 (ISO 8601)', example: '2026-05-03T19:30:00.000Z' })
   createdAt: string;
 
+  @ApiProperty({
+    description: '최종 수정 시간 (ISO 8601). createdAt과 다르면 수정된 글.',
+    example: '2026-05-03T19:30:00.000Z',
+  })
+  updatedAt: string;
+
   constructor(partial: Partial<FeedPostResponseDto>) {
     Object.assign(this, partial);
   }

--- a/apps/backend/src/post/feed/feed.module.ts
+++ b/apps/backend/src/post/feed/feed.module.ts
@@ -7,9 +7,10 @@ import { FeedCommentService } from '@/post/feed/comment/service';
 import { FeedCommentRepository } from '@/post/feed/comment/repository';
 import { DbModule } from '@/common/db/db.module';
 import { ReactionModule } from '@/reaction/reaction.module';
+import { PostSharedModule } from '@/post/shared/post-shared.module';
 
 @Module({
-  imports: [DbModule, ReactionModule],
+  imports: [DbModule, ReactionModule, PostSharedModule],
   controllers: [FeedController, FeedCommentController],
   providers: [FeedService, FeedRepository, FeedCommentService, FeedCommentRepository],
 })

--- a/apps/backend/src/post/feed/repository/feed.repository.ts
+++ b/apps/backend/src/post/feed/repository/feed.repository.ts
@@ -17,6 +17,7 @@ export interface FeedPostQueryResult {
   content: string;
   images: string[];
   createdAt: Date;
+  updatedAt: Date;
 }
 
 @Injectable()
@@ -25,6 +26,46 @@ export class FeedRepository {
     @Inject(DATABASE_CONNECTION)
     private readonly db: ReturnType<typeof drizzle>,
   ) {}
+
+  async findFeedPostMeta(postId: number): Promise<{ id: number; authorId: number } | null> {
+    const [row] = await this.db
+      .select({ id: Post.id, authorId: Post.authorId })
+      .from(Post)
+      .where(and(eq(Post.id, postId), eq(Post.post_type, PostType.FEED), eq(Post.deleted, false)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async updateFeedPost(
+    postId: number,
+    patch: { content?: string; images?: string[] },
+  ): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      if (patch.content !== undefined) {
+        const title = patch.content.slice(0, 50);
+        await tx.update(Post).set({ title, updatedAt: new Date() }).where(eq(Post.id, postId));
+        await tx
+          .update(FeedDetail)
+          .set({ content: patch.content, updatedAt: new Date() })
+          .where(eq(FeedDetail.postId, postId));
+      } else {
+        await tx.update(Post).set({ updatedAt: new Date() }).where(eq(Post.id, postId));
+      }
+
+      if (patch.images !== undefined) {
+        await tx.delete(PostImage).where(eq(PostImage.postId, postId));
+        if (patch.images.length > 0) {
+          await tx.insert(PostImage).values(
+            patch.images.map((imageUrl, idx) => ({
+              postId,
+              imageUrl,
+              imageOrder: idx,
+            })),
+          );
+        }
+      }
+    });
+  }
 
   async createFeedPost(authorId: number, content: string, images: string[]) {
     const title = content.slice(0, 50);
@@ -72,6 +113,7 @@ export class FeedRepository {
         supportTeam: Profile.supportTeam,
         content: FeedDetail.content,
         createdAt: Post.createdAt,
+        updatedAt: Post.updatedAt,
       })
       .from(Post)
       .innerJoin(FeedDetail, eq(Post.id, FeedDetail.postId))
@@ -98,6 +140,7 @@ export class FeedRepository {
       content: base.content,
       images: imageRows.map((row) => row.imageUrl),
       createdAt: base.createdAt,
+      updatedAt: base.updatedAt,
     };
   }
 
@@ -115,6 +158,7 @@ export class FeedRepository {
         supportTeam: Profile.supportTeam,
         content: FeedDetail.content,
         createdAt: Post.createdAt,
+        updatedAt: Post.updatedAt,
       })
       .from(Post)
       .innerJoin(FeedDetail, eq(Post.id, FeedDetail.postId))
@@ -151,6 +195,7 @@ export class FeedRepository {
       content: row.content,
       images: imagesByPostId[row.id] ?? [],
       createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
     }));
   }
 }

--- a/apps/backend/src/post/feed/service/feed.service.ts
+++ b/apps/backend/src/post/feed/service/feed.service.ts
@@ -1,15 +1,23 @@
-import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { FeedRepository, type FeedPostQueryResult } from '@/post/feed/repository';
 import {
   CreateFeedPostRequestDto,
   FeedPostResponseDto,
   GetFeedPostsResponseDto,
+  UpdateFeedPostRequestDto,
 } from '@/post/feed/dto';
 import { AuthorDto, AuthorType } from '@/post/shared/dto/author.dto';
 import { Team } from '@/common/enums';
 import { ReactionRepository } from '@/reaction/repository';
 import { ReactionTargetType } from '@/reaction/domain';
 import { FeedCommentRepository } from '@/post/feed/comment/repository';
+import { PostSharedRepository } from '@/post/shared/repository';
 
 @Injectable()
 export class FeedService {
@@ -17,6 +25,7 @@ export class FeedService {
     private readonly feedRepository: FeedRepository,
     private readonly reactionRepository: ReactionRepository,
     private readonly feedCommentRepository: FeedCommentRepository,
+    private readonly postSharedRepository: PostSharedRepository,
   ) {}
 
   async createFeedPost(
@@ -33,6 +42,48 @@ export class FeedService {
     }
 
     return this.toResponse(detail, 0, false, 0);
+  }
+
+  async updateFeedPost(
+    memberId: number,
+    postId: number,
+    dto: UpdateFeedPostRequestDto,
+  ): Promise<FeedPostResponseDto> {
+    if (dto.content === undefined && dto.images === undefined) {
+      throw new BadRequestException('content 또는 images 중 최소 하나는 전달해야 합니다.');
+    }
+
+    const meta = await this.feedRepository.findFeedPostMeta(postId);
+    if (!meta) {
+      throw new NotFoundException('해당 게시글을 찾을 수 없습니다.');
+    }
+    if (meta.authorId !== memberId) {
+      throw new ForbiddenException('작성자만 수정할 수 있습니다.');
+    }
+
+    await this.feedRepository.updateFeedPost(postId, {
+      content: dto.content,
+      images: dto.images,
+    });
+
+    return this.getFeedPostDetail(postId, memberId);
+  }
+
+  async deleteFeedPost(memberId: number, postId: number): Promise<{ id: number }> {
+    const meta = await this.feedRepository.findFeedPostMeta(postId);
+    if (!meta) {
+      throw new NotFoundException('해당 게시글을 찾을 수 없습니다.');
+    }
+    if (meta.authorId !== memberId) {
+      throw new ForbiddenException('작성자만 삭제할 수 있습니다.');
+    }
+
+    const deleted = await this.postSharedRepository.softDelete(postId);
+    if (!deleted) {
+      throw new NotFoundException('해당 게시글을 찾을 수 없습니다.');
+    }
+
+    return { id: deleted.id };
   }
 
   async getFeedPostDetail(
@@ -139,6 +190,7 @@ export class FeedService {
       isLiked,
       commentCount,
       createdAt: detail.createdAt.toISOString(),
+      updatedAt: detail.updatedAt.toISOString(),
     });
   }
 }

--- a/apps/backend/src/post/feed/swagger/delete-feed-post.swagger.ts
+++ b/apps/backend/src/post/feed/swagger/delete-feed-post.swagger.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+} from '@nestjs/swagger';
+import { ErrorResponseDto } from '@/common';
+
+export const DeleteFeedPostSwagger = applyDecorators(
+  ApiOperation({
+    summary: '피드 게시글 삭제 (soft delete)',
+    description: '작성자 본인이 자신의 피드 게시글을 소프트 삭제합니다.',
+  }),
+  ApiParam({ name: 'postId', type: Number, description: '삭제할 게시글 ID', example: 1 }),
+  ApiOkResponse({
+    description: '삭제 성공. 삭제된 게시글 ID 반환',
+    schema: {
+      type: 'object',
+      properties: { id: { type: 'number', example: 1 } },
+    },
+  }),
+  ApiUnauthorizedResponse({ type: ErrorResponseDto, description: '인증되지 않은 사용자' }),
+  ApiForbiddenResponse({ type: ErrorResponseDto, description: '작성자가 아니어서 권한 없음' }),
+  ApiNotFoundResponse({ type: ErrorResponseDto, description: '게시글을 찾을 수 없음' }),
+  ApiInternalServerErrorResponse({ type: ErrorResponseDto, description: '서버 내부 오류' }),
+);

--- a/apps/backend/src/post/feed/swagger/index.ts
+++ b/apps/backend/src/post/feed/swagger/index.ts
@@ -2,3 +2,5 @@ export * from './feed-controller.swagger';
 export * from './create-feed-post.swagger';
 export * from './get-feed-post-detail.swagger';
 export * from './get-feed-posts.swagger';
+export * from './update-feed-post.swagger';
+export * from './delete-feed-post.swagger';

--- a/apps/backend/src/post/feed/swagger/update-feed-post.swagger.ts
+++ b/apps/backend/src/post/feed/swagger/update-feed-post.swagger.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+} from '@nestjs/swagger';
+import { FeedPostResponseDto, UpdateFeedPostRequestDto } from '@/post/feed/dto';
+import { ErrorResponseDto } from '@/common';
+
+export const UpdateFeedPostSwagger = applyDecorators(
+  ApiOperation({
+    summary: '피드 게시글 수정',
+    description:
+      '작성자 본인만 수정 가능. content/images 중 하나 이상 전달. images는 전체 교체이며 빈 배열을 보내면 모든 이미지가 제거됩니다.',
+  }),
+  ApiParam({ name: 'postId', type: Number, description: '수정할 게시글 ID', example: 1 }),
+  ApiBody({ type: UpdateFeedPostRequestDto }),
+  ApiOkResponse({ type: FeedPostResponseDto, description: '수정된 피드 게시글' }),
+  ApiBadRequestResponse({
+    type: ErrorResponseDto,
+    description: '본문/이미지 모두 누락 또는 유효성 검사 실패',
+  }),
+  ApiUnauthorizedResponse({ type: ErrorResponseDto, description: '인증되지 않은 사용자' }),
+  ApiForbiddenResponse({ type: ErrorResponseDto, description: '작성자가 아니어서 권한 없음' }),
+  ApiNotFoundResponse({ type: ErrorResponseDto, description: '게시글을 찾을 수 없음' }),
+  ApiInternalServerErrorResponse({ type: ErrorResponseDto, description: '서버 내부 오류' }),
+);

--- a/apps/frontend/src/apis/feed/comment.ts
+++ b/apps/frontend/src/apis/feed/comment.ts
@@ -36,3 +36,17 @@ export async function deleteFeedComment(
     authRequired: true,
   });
 }
+
+export interface UpdateFeedCommentRequest {
+  content: string;
+}
+
+export async function updateFeedComment(
+  postId: number,
+  commentId: number,
+  body: UpdateFeedCommentRequest,
+): Promise<FeedComment> {
+  return apiClient.patch<FeedComment>(`/post/feed/${postId}/comments/${commentId}`, body, {
+    authRequired: true,
+  });
+}

--- a/apps/frontend/src/apis/feed/feed.ts
+++ b/apps/frontend/src/apis/feed/feed.ts
@@ -31,3 +31,16 @@ export interface CreateFeedPostRequest {
 export async function createFeedPost(body: CreateFeedPostRequest): Promise<FeedPost> {
   return apiClient.post<FeedPost>('/post/feed', body, { authRequired: true });
 }
+
+export interface UpdateFeedPostRequest {
+  content?: string;
+  images?: string[];
+}
+
+export async function updateFeedPost(id: number, body: UpdateFeedPostRequest): Promise<FeedPost> {
+  return apiClient.patch<FeedPost>(`/post/feed/${id}`, body, { authRequired: true });
+}
+
+export async function deleteFeedPost(id: number): Promise<{ id: number }> {
+  return apiClient.delete<{ id: number }>(`/post/feed/${id}`, { authRequired: true });
+}

--- a/apps/frontend/src/app/feed/[id]/components/CommentInput.tsx
+++ b/apps/frontend/src/app/feed/[id]/components/CommentInput.tsx
@@ -10,6 +10,9 @@ interface CommentInputProps {
   onSubmit: (content: string) => void;
   onCancel?: () => void;
   autoFocus?: boolean;
+  initialValue?: string;
+  submitLabel?: string;
+  submittingLabel?: string;
 }
 
 const MAX_LENGTH = 1000;
@@ -20,14 +23,21 @@ export function CommentInput({
   onSubmit,
   onCancel,
   autoFocus = false,
+  initialValue = '',
+  submitLabel = '등록',
+  submittingLabel = '등록 중',
 }: CommentInputProps) {
-  const [value, setValue] = useState('');
-  const canSubmit = value.trim().length > 0 && value.length <= MAX_LENGTH && !isSubmitting;
+  const [value, setValue] = useState(initialValue);
+  const canSubmit =
+    value.trim().length > 0 &&
+    value.length <= MAX_LENGTH &&
+    !isSubmitting &&
+    value.trim() !== initialValue.trim();
 
   const handleSubmit = () => {
     if (!canSubmit) return;
     onSubmit(value.trim());
-    setValue('');
+    setValue(initialValue);
   };
 
   return (
@@ -62,7 +72,7 @@ export function CommentInput({
           )}
         >
           {isSubmitting ? <Loader2 className="animate-spin" size={14} /> : <Send size={14} />}
-          <span>{isSubmitting ? '등록 중' : '등록'}</span>
+          <span>{isSubmitting ? submittingLabel : submitLabel}</span>
         </button>
       </div>
     </div>

--- a/apps/frontend/src/app/feed/[id]/components/CommentItem.tsx
+++ b/apps/frontend/src/app/feed/[id]/components/CommentItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { MessageSquare, Trash2 } from 'lucide-react';
+import { MessageSquare, Pencil, Trash2 } from 'lucide-react';
 import { TeamDescription } from '@homerunnie/shared';
 import { TeamProfileAvatar } from '@/shared/ui/profile/team-profile-avatar';
 import { cn } from '@/lib/utils';
@@ -25,9 +25,11 @@ interface CommentItemProps {
   isReply?: boolean;
   isReplyingTarget?: boolean;
   isCreatingReply?: boolean;
+  isUpdatingComment?: boolean;
   onReplyToggle?: (commentId: number) => void;
   onReplySubmit?: (parentId: number, content: string) => void;
   onDelete?: (commentId: number) => void;
+  onUpdate?: (commentId: number, content: string) => void;
   onAuthRequired?: () => void;
 }
 
@@ -37,13 +39,16 @@ export function CommentItem({
   isReply = false,
   isReplyingTarget = false,
   isCreatingReply = false,
+  isUpdatingComment = false,
   onReplyToggle,
   onReplySubmit,
   onDelete,
+  onUpdate,
   onAuthRequired,
 }: CommentItemProps) {
   const isMine = viewerMemberId !== null && comment.author.id === viewerMemberId;
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const handleReplyClick = () => {
     if (viewerMemberId === null) {
@@ -76,35 +81,67 @@ export function CommentItem({
               </span>
             )}
           </div>
-          <p className="text-b03-r text-gray-800 whitespace-pre-wrap mt-0.5">{comment.content}</p>
-          <div className="flex items-center gap-3 mt-1.5">
-            <time className="text-c01-r text-gray-400" dateTime={comment.createdAt}>
-              {formatRelativeTime(comment.createdAt)}
-            </time>
-            {!isReply && onReplyToggle && (
-              <button
-                type="button"
-                onClick={handleReplyClick}
-                className="inline-flex items-center gap-1 text-c01-r text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <MessageSquare size={12} />
-                <span>답글</span>
-              </button>
-            )}
-            {isMine && onDelete && (
-              <button
-                type="button"
-                onClick={handleDeleteClick}
-                className={cn(
-                  'inline-flex items-center gap-1 text-c01-r transition-colors',
-                  confirmDelete ? 'text-red-600 font-semibold' : 'text-gray-500 hover:text-red-500',
-                )}
-              >
-                <Trash2 size={12} />
-                <span>{confirmDelete ? '한번 더 클릭' : '삭제'}</span>
-              </button>
-            )}
-          </div>
+          {isEditing ? (
+            <div className="mt-1">
+              <CommentInput
+                initialValue={comment.content}
+                placeholder="댓글을 입력하세요"
+                isSubmitting={isUpdatingComment}
+                submitLabel="저장"
+                submittingLabel="저장 중"
+                onSubmit={(content) => {
+                  onUpdate?.(comment.id, content);
+                  setIsEditing(false);
+                }}
+                onCancel={() => setIsEditing(false)}
+                autoFocus
+              />
+            </div>
+          ) : (
+            <p className="text-b03-r text-gray-800 whitespace-pre-wrap mt-0.5">{comment.content}</p>
+          )}
+          {!isEditing && (
+            <div className="flex items-center gap-3 mt-1.5">
+              <time className="text-c01-r text-gray-400" dateTime={comment.createdAt}>
+                {formatRelativeTime(comment.createdAt)}
+              </time>
+              {!isReply && onReplyToggle && (
+                <button
+                  type="button"
+                  onClick={handleReplyClick}
+                  className="inline-flex items-center gap-1 text-c01-r text-gray-500 hover:text-gray-700 transition-colors"
+                >
+                  <MessageSquare size={12} />
+                  <span>답글</span>
+                </button>
+              )}
+              {isMine && onUpdate && (
+                <button
+                  type="button"
+                  onClick={() => setIsEditing(true)}
+                  className="inline-flex items-center gap-1 text-c01-r text-gray-500 hover:text-gray-700 transition-colors"
+                >
+                  <Pencil size={12} />
+                  <span>수정</span>
+                </button>
+              )}
+              {isMine && onDelete && (
+                <button
+                  type="button"
+                  onClick={handleDeleteClick}
+                  className={cn(
+                    'inline-flex items-center gap-1 text-c01-r transition-colors',
+                    confirmDelete
+                      ? 'text-red-600 font-semibold'
+                      : 'text-gray-500 hover:text-red-500',
+                  )}
+                >
+                  <Trash2 size={12} />
+                  <span>{confirmDelete ? '한번 더 클릭' : '삭제'}</span>
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -128,7 +165,9 @@ export function CommentItem({
               comment={reply}
               viewerMemberId={viewerMemberId}
               isReply
+              isUpdatingComment={isUpdatingComment}
               onDelete={onDelete}
+              onUpdate={onUpdate}
               onAuthRequired={onAuthRequired}
             />
           ))}

--- a/apps/frontend/src/app/feed/[id]/components/CommentItem.tsx
+++ b/apps/frontend/src/app/feed/[id]/components/CommentItem.tsx
@@ -129,12 +129,9 @@ export function CommentItem({
                 <button
                   type="button"
                   onClick={handleDeleteClick}
-                  className={cn(
-                    'inline-flex items-center gap-1 text-c01-r transition-colors',
-                    confirmDelete
-                      ? 'text-red-600 font-semibold'
-                      : 'text-gray-500 hover:text-red-500',
-                  )}
+                  className={`inline-flex items-center gap-1 text-c01-r transition-colors ${
+                    confirmDelete ? 'text-red-600' : 'text-gray-500 hover:text-red-500'
+                  }`}
                 >
                   <Trash2 size={12} />
                   <span>{confirmDelete ? '한번 더 클릭' : '삭제'}</span>

--- a/apps/frontend/src/app/feed/[id]/components/CommentList.tsx
+++ b/apps/frontend/src/app/feed/[id]/components/CommentList.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { useFeedCommentsQuery } from '@/hooks/feed/useFeedCommentsQuery';
 import { useCreateFeedCommentMutation } from '@/hooks/feed/useCreateFeedCommentMutation';
 import { useDeleteFeedCommentMutation } from '@/hooks/feed/useDeleteFeedCommentMutation';
+import { useUpdateFeedCommentMutation } from '@/hooks/feed/useUpdateFeedCommentMutation';
 import { CommentInput } from './CommentInput';
 import { CommentItem } from './CommentItem';
 
@@ -18,6 +19,7 @@ export function CommentList({ postId, viewerMemberId, onAuthRequired }: CommentL
   const { data: comments, isLoading, isError, error } = useFeedCommentsQuery(postId);
   const createMutation = useCreateFeedCommentMutation(postId);
   const deleteMutation = useDeleteFeedCommentMutation(postId);
+  const updateMutation = useUpdateFeedCommentMutation(postId);
   const [replyingTo, setReplyingTo] = useState<number | null>(null);
 
   const isLogged = viewerMemberId !== null;
@@ -45,6 +47,10 @@ export function CommentList({ postId, viewerMemberId, onAuthRequired }: CommentL
 
   const handleDelete = (commentId: number) => {
     deleteMutation.mutate(commentId);
+  };
+
+  const handleUpdate = (commentId: number, content: string) => {
+    updateMutation.mutate({ commentId, content });
   };
 
   const handleReplyToggle = (commentId: number) => {
@@ -91,9 +97,11 @@ export function CommentList({ postId, viewerMemberId, onAuthRequired }: CommentL
             viewerMemberId={viewerMemberId}
             isReplyingTarget={replyingTo === comment.id}
             isCreatingReply={createMutation.isPending && replyingTo === comment.id}
+            isUpdatingComment={updateMutation.isPending}
             onReplyToggle={handleReplyToggle}
             onReplySubmit={handleReplySubmit}
             onDelete={handleDelete}
+            onUpdate={handleUpdate}
             onAuthRequired={handleAuthRequired}
           />
         ))}

--- a/apps/frontend/src/app/feed/[id]/edit/page.tsx
+++ b/apps/frontend/src/app/feed/[id]/edit/page.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, ImagePlus, Loader2, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useFeedPostQuery } from '@/hooks/feed/useFeedPostQuery';
+import { useUpdateFeedPostMutation } from '@/hooks/feed/useUpdateFeedPostMutation';
+import { useMyProfileQuery } from '@/hooks/my/useProfileQuery';
+import LoginRequiredModal from '@/shared/ui/modal/LoginRequiredModal';
+
+const MAX_IMAGES = 4;
+const MAX_CONTENT = 2000;
+
+interface ImageItem {
+  url: string;
+  isNew: boolean;
+  previewUrl?: string;
+}
+
+interface FeedEditPageProps {
+  params: { id: string };
+}
+
+export default function FeedEditPage({ params }: FeedEditPageProps) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const postId = Number(params.id);
+
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    isError: isProfileError,
+  } = useMyProfileQuery({ retry: false });
+  const isLogged = useMemo(
+    () => !isProfileError && Boolean(profile?.nickname),
+    [profile?.nickname, isProfileError],
+  );
+
+  const { data: post, isLoading, isError, error } = useFeedPostQuery(postId);
+
+  const [content, setContent] = useState('');
+  const [images, setImages] = useState<ImageItem[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (post && !hydrated) {
+      setContent(post.content);
+      setImages(post.images.map((url) => ({ url, isNew: false })));
+      setHydrated(true);
+    }
+  }, [post, hydrated]);
+
+  useEffect(() => {
+    if (!isProfileLoading && !isLogged) {
+      setLoginModalOpen(true);
+    }
+  }, [isProfileLoading, isLogged]);
+
+  useEffect(() => {
+    if (post && profile?.memberId && post.author.id !== profile.memberId) {
+      router.replace(`/feed/${postId}`);
+    }
+  }, [post, profile?.memberId, router, postId]);
+
+  const {
+    mutate,
+    isPending,
+    isError: isMutateError,
+    error: mutateError,
+  } = useUpdateFeedPostMutation({
+    onSuccess: () => router.replace(`/feed/${postId}`),
+  });
+
+  useEffect(() => {
+    return () => {
+      images.forEach((img) => {
+        if (img.previewUrl) URL.revokeObjectURL(img.previewUrl);
+      });
+    };
+  }, [images]);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    const remaining = MAX_IMAGES - images.length;
+    const accepted = files.slice(0, remaining);
+
+    const newItems: ImageItem[] = accepted.map((file, i) => ({
+      url: `https://picsum.photos/seed/edit-${Date.now()}-${i}/800/600`,
+      previewUrl: URL.createObjectURL(file),
+      isNew: true,
+    }));
+
+    setImages((prev) => [...prev, ...newItems]);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removeImage = (idx: number) => {
+    setImages((prev) => {
+      const target = prev[idx];
+      if (target.previewUrl) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((_, i) => i !== idx);
+    });
+  };
+
+  const isUnchanged = useMemo(() => {
+    if (!post) return true;
+    if (content !== post.content) return false;
+    if (images.length !== post.images.length) return false;
+    return images.every((img, i) => !img.isNew && img.url === post.images[i]);
+  }, [content, images, post]);
+
+  const canSubmit =
+    hydrated &&
+    content.trim().length > 0 &&
+    content.length <= MAX_CONTENT &&
+    !isPending &&
+    !isUnchanged;
+
+  const onSubmit = () => {
+    if (!canSubmit || !post) return;
+    mutate({
+      id: postId,
+      body: {
+        content: content !== post.content ? content.trim() : undefined,
+        images: images.map((img) => img.url),
+      },
+    });
+  };
+
+  return (
+    <div className="max-w-[600px] mx-auto py-4">
+      <div className="flex items-center justify-between mb-3 px-1">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="inline-flex items-center gap-1 text-c01-m text-gray-700 hover:text-gray-900 transition-colors"
+          aria-label="뒤로가기"
+        >
+          <ArrowLeft size={18} />
+          <span>뒤로</span>
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={!canSubmit}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-c01-m transition-colors',
+            canSubmit
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'bg-gray-200 text-gray-500 cursor-not-allowed',
+          )}
+        >
+          {isPending && <Loader2 className="animate-spin" size={14} />}
+          <span>{isPending ? '저장 중...' : '저장'}</span>
+        </button>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <Loader2 className="animate-spin text-gray-500" size={28} />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-col items-center justify-center min-h-[40vh] gap-2">
+          <p className="text-b02-sb text-gray-700">게시글을 불러오지 못했어요.</p>
+          <p className="text-c01-r text-gray-500">{error?.message}</p>
+        </div>
+      )}
+
+      {post && (
+        <div className="bg-background rounded-2xl border border-gray-100 p-4">
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="무엇을 공유하고 싶나요?"
+            maxLength={MAX_CONTENT + 100}
+            className="w-full min-h-[200px] resize-none outline-none text-b03-r text-gray-800 placeholder:text-gray-400"
+          />
+
+          {images.length > 0 && (
+            <div className="grid grid-cols-2 gap-1 mt-3">
+              {images.map((img, idx) => (
+                <div
+                  key={img.previewUrl ?? img.url}
+                  className="relative aspect-square overflow-hidden rounded-lg"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={img.previewUrl ?? img.url}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(idx)}
+                    className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80 transition-colors"
+                    aria-label="이미지 삭제"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-100">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={images.length >= MAX_IMAGES}
+              className={cn(
+                'inline-flex items-center gap-1.5 text-c01-m transition-colors',
+                images.length >= MAX_IMAGES
+                  ? 'text-gray-300 cursor-not-allowed'
+                  : 'text-gray-700 hover:text-gray-900',
+              )}
+            >
+              <ImagePlus size={18} />
+              <span>
+                사진 {images.length}/{MAX_IMAGES}
+              </span>
+            </button>
+            <span
+              className={cn(
+                'text-c01-r',
+                content.length > MAX_CONTENT ? 'text-red-500' : 'text-gray-400',
+              )}
+            >
+              {content.length}/{MAX_CONTENT}
+            </span>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={handleFileChange}
+            className="hidden"
+          />
+        </div>
+      )}
+
+      {isMutateError && (
+        <p className="text-c01-r text-red-500 mt-3 px-1">
+          저장 실패: {(mutateError as Error)?.message}
+        </p>
+      )}
+
+      <LoginRequiredModal
+        open={loginModalOpen}
+        onOpenChange={(open) => {
+          setLoginModalOpen(open);
+          if (!open && !isLogged) {
+            router.replace('/feed');
+          }
+        }}
+        onConfirm={() => router.push('/login')}
+        title="로그인이 필요해요"
+        description="글을 수정하려면 로그인이 필요합니다."
+        confirmText="로그인 하러가기"
+        cancelText="피드로 돌아가기"
+        showCancel
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/feed/[id]/page.tsx
+++ b/apps/frontend/src/app/feed/[id]/page.tsx
@@ -7,8 +7,10 @@ import { FeedCard } from '@/shared/ui/feed-card/feed-card';
 import type { FeedPost } from '@/shared/ui/feed-card/feed-card.types';
 import { useFeedPostQuery } from '@/hooks/feed/useFeedPostQuery';
 import { useToggleLikeMutation } from '@/hooks/feed/useToggleLikeMutation';
+import { useDeleteFeedPostMutation } from '@/hooks/feed/useDeleteFeedPostMutation';
 import { useMyProfileQuery } from '@/hooks/my/useProfileQuery';
 import LoginRequiredModal from '@/shared/ui/modal/LoginRequiredModal';
+import ConfirmModal from '@/shared/ui/modal/ConfirmModal';
 import { CommentList } from './components/CommentList';
 
 interface FeedDetailPageProps {
@@ -34,8 +36,15 @@ export default function FeedDetailPage({ params }: FeedDetailPageProps) {
     open: false,
     message: '',
   });
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const toggleLikeMutation = useToggleLikeMutation();
+  const deletePostMutation = useDeleteFeedPostMutation({
+    onSuccess: () => {
+      setDeleteOpen(false);
+      router.push('/feed');
+    },
+  });
 
   const showLoginModal = (message: string) => {
     setLoginModal({ open: true, message });
@@ -76,7 +85,14 @@ export default function FeedDetailPage({ params }: FeedDetailPageProps) {
 
       {post && (
         <>
-          <FeedCard post={post} expanded onLikeClick={handleLikeClick} />
+          <FeedCard
+            post={post}
+            viewerMemberId={viewerMemberId}
+            expanded
+            onLikeClick={handleLikeClick}
+            onEditClick={(p) => router.push(`/feed/${p.id}/edit`)}
+            onDeleteClick={() => setDeleteOpen(true)}
+          />
 
           <div className="mt-3">
             <CommentList
@@ -87,6 +103,20 @@ export default function FeedDetailPage({ params }: FeedDetailPageProps) {
           </div>
         </>
       )}
+
+      <ConfirmModal
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={() => {
+          if (post) deletePostMutation.mutate(post.id);
+        }}
+        title="게시글을 삭제하시겠어요?"
+        description="삭제된 게시글은 복구할 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        destructive
+        isPending={deletePostMutation.isPending}
+      />
 
       <LoginRequiredModal
         open={loginModal.open}

--- a/apps/frontend/src/app/feed/page.tsx
+++ b/apps/frontend/src/app/feed/page.tsx
@@ -7,8 +7,10 @@ import { FeedCard } from '@/shared/ui/feed-card/feed-card';
 import type { FeedPost } from '@/shared/ui/feed-card/feed-card.types';
 import { useFeedInfiniteQuery } from '@/hooks/feed/useFeedInfiniteQuery';
 import { useToggleLikeMutation } from '@/hooks/feed/useToggleLikeMutation';
+import { useDeleteFeedPostMutation } from '@/hooks/feed/useDeleteFeedPostMutation';
 import { useMyProfileQuery } from '@/hooks/my/useProfileQuery';
 import LoginRequiredModal from '@/shared/ui/modal/LoginRequiredModal';
+import ConfirmModal from '@/shared/ui/modal/ConfirmModal';
 
 export default function FeedPage() {
   const router = useRouter();
@@ -20,13 +22,22 @@ export default function FeedPage() {
     [profile?.nickname, isProfileError],
   );
 
+  const viewerMemberId = useMemo(
+    () => (isLogged && profile?.memberId ? profile.memberId : null),
+    [isLogged, profile?.memberId],
+  );
+
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [loginModal, setLoginModal] = useState<{ open: boolean; message: string }>({
     open: false,
     message: '',
   });
+  const [deleteTarget, setDeleteTarget] = useState<FeedPost | null>(null);
 
   const toggleLikeMutation = useToggleLikeMutation();
+  const deletePostMutation = useDeleteFeedPostMutation({
+    onSuccess: () => setDeleteTarget(null),
+  });
 
   const showLoginModal = (message: string) => {
     setLoginModal({ open: true, message });
@@ -97,8 +108,11 @@ export default function FeedPage() {
                 <FeedCard
                   key={post.id}
                   post={post}
+                  viewerMemberId={viewerMemberId}
                   onCardClick={(p) => router.push(`/feed/${p.id}`)}
                   onLikeClick={handleLikeClick}
+                  onEditClick={(p) => router.push(`/feed/${p.id}/edit`)}
+                  onDeleteClick={(p) => setDeleteTarget(p)}
                 />
               ))}
             </div>
@@ -132,6 +146,22 @@ export default function FeedPage() {
         confirmText="로그인 하러가기"
         cancelText="다음에"
         showCancel
+      />
+
+      <ConfirmModal
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={() => {
+          if (deleteTarget) deletePostMutation.mutate(deleteTarget.id);
+        }}
+        title="게시글을 삭제하시겠어요?"
+        description="삭제된 게시글은 복구할 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        destructive
+        isPending={deletePostMutation.isPending}
       />
     </>
   );

--- a/apps/frontend/src/hooks/feed/useDeleteFeedPostMutation.ts
+++ b/apps/frontend/src/hooks/feed/useDeleteFeedPostMutation.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteFeedPost, type GetFeedPostsResponse } from '@/apis/feed/feed';
+
+interface Options {
+  onSuccess?: (postId: number) => void;
+  onError?: (error: Error) => void;
+}
+
+export const useDeleteFeedPostMutation = ({ onSuccess, onError }: Options = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ id: number }, Error, number>({
+    mutationFn: (postId) => deleteFeedPost(postId),
+    onSuccess: (_, postId) => {
+      queryClient.removeQueries({ queryKey: ['feed-post', postId] });
+
+      queryClient.setQueriesData<{
+        pages: GetFeedPostsResponse[];
+        pageParams: (string | null)[];
+      }>({ queryKey: ['feed'] }, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.filter((item) => item.id !== postId),
+          })),
+        };
+      });
+
+      onSuccess?.(postId);
+    },
+    onError,
+  });
+};

--- a/apps/frontend/src/hooks/feed/useUpdateFeedCommentMutation.ts
+++ b/apps/frontend/src/hooks/feed/useUpdateFeedCommentMutation.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateFeedComment, type FeedComment } from '@/apis/feed/comment';
+
+interface Variables {
+  commentId: number;
+  content: string;
+}
+
+interface Options {
+  onSuccess?: (comment: FeedComment) => void;
+  onError?: (error: Error) => void;
+}
+
+export const useUpdateFeedCommentMutation = (
+  postId: number,
+  { onSuccess, onError }: Options = {},
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<FeedComment, Error, Variables>({
+    mutationFn: ({ commentId, content }) => updateFeedComment(postId, commentId, { content }),
+    onSuccess: (comment) => {
+      queryClient.invalidateQueries({ queryKey: ['feed-comments', postId] });
+      onSuccess?.(comment);
+    },
+    onError,
+  });
+};

--- a/apps/frontend/src/hooks/feed/useUpdateFeedPostMutation.ts
+++ b/apps/frontend/src/hooks/feed/useUpdateFeedPostMutation.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateFeedPost, type UpdateFeedPostRequest } from '@/apis/feed/feed';
+import type { GetFeedPostsResponse } from '@/apis/feed/feed';
+import type { FeedPost } from '@/shared/ui/feed-card/feed-card.types';
+
+interface Variables {
+  id: number;
+  body: UpdateFeedPostRequest;
+}
+
+interface Options {
+  onSuccess?: (post: FeedPost) => void;
+  onError?: (error: Error) => void;
+}
+
+export const useUpdateFeedPostMutation = ({ onSuccess, onError }: Options = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<FeedPost, Error, Variables>({
+    mutationFn: ({ id, body }) => updateFeedPost(id, body),
+    onSuccess: (post) => {
+      queryClient.setQueryData<FeedPost>(['feed-post', post.id], post);
+
+      queryClient.setQueriesData<{
+        pages: GetFeedPostsResponse[];
+        pageParams: (string | null)[];
+      }>({ queryKey: ['feed'] }, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) => (item.id === post.id ? post : item)),
+          })),
+        };
+      });
+
+      onSuccess?.(post);
+    },
+    onError,
+  });
+};

--- a/apps/frontend/src/mocks/data/feed-mock-data.ts
+++ b/apps/frontend/src/mocks/data/feed-mock-data.ts
@@ -79,6 +79,7 @@ export function generateMockFeedPost(id: number): FeedPost {
     isLiked: id % 3 === 0,
     commentCount: (id * 3) % 30,
     createdAt: new Date(Date.now() - minutesAgo * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - minutesAgo * 60 * 1000).toISOString(),
   };
 }
 

--- a/apps/frontend/src/mocks/feed-handlers.ts
+++ b/apps/frontend/src/mocks/feed-handlers.ts
@@ -79,6 +79,7 @@ export const feedHandlers = [
       isLiked: false,
       commentCount: 0,
       createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     };
 
     runtimePosts.unshift(newPost);

--- a/apps/frontend/src/shared/ui/feed-card/FeedCardKebabMenu.tsx
+++ b/apps/frontend/src/shared/ui/feed-card/FeedCardKebabMenu.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface FeedCardKebabMenuProps {
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export function FeedCardKebabMenu({ onEdit, onDelete }: FeedCardKebabMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="p-1.5 -m-1.5 rounded-full text-gray-500 hover:bg-gray-100 transition-colors"
+        aria-label="더보기"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <MoreHorizontal size={18} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            'absolute right-0 top-full mt-1 z-10',
+            'min-w-[120px] bg-background rounded-lg border border-gray-100 shadow-md',
+            'overflow-hidden',
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {onEdit && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                onEdit();
+              }}
+              className="w-full inline-flex items-center gap-2 px-3 py-2 text-c01-m text-gray-800 hover:bg-gray-50 transition-colors"
+            >
+              <Pencil size={14} />
+              <span>수정</span>
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                onDelete();
+              }}
+              className="w-full inline-flex items-center gap-2 px-3 py-2 text-c01-m text-red-500 hover:bg-red-50 transition-colors"
+            >
+              <Trash2 size={14} />
+              <span>삭제</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/shared/ui/feed-card/feed-card.tsx
+++ b/apps/frontend/src/shared/ui/feed-card/feed-card.tsx
@@ -5,6 +5,7 @@ import { TeamDescription } from '@homerunnie/shared';
 import { TeamProfileAvatar } from '@/shared/ui/profile/team-profile-avatar';
 import { cn } from '@/lib/utils';
 import type { FeedPost } from './feed-card.types';
+import { FeedCardKebabMenu } from './FeedCardKebabMenu';
 
 function formatRelativeTime(iso: string): string {
   const now = Date.now();
@@ -41,22 +42,32 @@ function ImageGrid({ images }: { images: string[] }) {
 
 export interface FeedCardProps {
   post: FeedPost;
+  viewerMemberId?: number | null;
   onLikeClick?: (post: FeedPost) => void;
   onCommentClick?: (post: FeedPost) => void;
   onCardClick?: (post: FeedPost) => void;
+  onEditClick?: (post: FeedPost) => void;
+  onDeleteClick?: (post: FeedPost) => void;
   expanded?: boolean;
   className?: string;
 }
 
 export function FeedCard({
   post,
+  viewerMemberId,
   onLikeClick,
   onCommentClick,
   onCardClick,
+  onEditClick,
+  onDeleteClick,
   expanded = false,
   className,
 }: FeedCardProps) {
-  const { author, content, images, likeCount, isLiked, commentCount, createdAt } = post;
+  const { author, content, images, likeCount, isLiked, commentCount, createdAt, updatedAt } = post;
+  const isMine =
+    viewerMemberId !== undefined && viewerMemberId !== null && author.id === viewerMemberId;
+  const showKebab = isMine && (onEditClick || onDeleteClick);
+  const isEdited = updatedAt && updatedAt !== createdAt;
 
   return (
     <article
@@ -78,10 +89,19 @@ export function FeedCard({
               </span>
             )}
           </div>
-          <time className="text-c01-r text-gray-400" dateTime={createdAt}>
-            {formatRelativeTime(createdAt)}
-          </time>
+          <div className="flex items-center gap-1.5">
+            <time className="text-c01-r text-gray-400" dateTime={createdAt}>
+              {formatRelativeTime(createdAt)}
+            </time>
+            {isEdited && <span className="text-c01-r text-gray-400">· 수정됨</span>}
+          </div>
         </div>
+        {showKebab && (
+          <FeedCardKebabMenu
+            onEdit={onEditClick ? () => onEditClick(post) : undefined}
+            onDelete={onDeleteClick ? () => onDeleteClick(post) : undefined}
+          />
+        )}
       </header>
 
       <div className="px-4 py-3">

--- a/apps/frontend/src/shared/ui/feed-card/feed-card.types.ts
+++ b/apps/frontend/src/shared/ui/feed-card/feed-card.types.ts
@@ -16,4 +16,5 @@ export interface FeedPost {
   isLiked: boolean;
   commentCount: number;
   createdAt: string;
+  updatedAt: string;
 }

--- a/apps/frontend/src/shared/ui/feed-card/storybook/feed-card.stories.tsx
+++ b/apps/frontend/src/shared/ui/feed-card/storybook/feed-card.stories.tsx
@@ -25,6 +25,7 @@ const basePost: FeedPost = {
   isLiked: false,
   commentCount: 5,
   createdAt: new Date(Date.now() - 1000 * 60 * 7).toISOString(),
+  updatedAt: new Date(Date.now() - 1000 * 60 * 7).toISOString(),
 };
 
 const meta = {

--- a/apps/frontend/src/shared/ui/modal/ConfirmModal.tsx
+++ b/apps/frontend/src/shared/ui/modal/ConfirmModal.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/primitives/dialog';
+import { Button } from '@/shared/ui/primitives/button';
+
+interface ConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  destructive?: boolean;
+  isPending?: boolean;
+}
+
+export default function ConfirmModal({
+  open,
+  onOpenChange,
+  onConfirm,
+  title,
+  description,
+  confirmText = '확인',
+  cancelText = '취소',
+  destructive = false,
+  isPending = false,
+}: ConfirmModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            {cancelText}
+          </Button>
+          <Button
+            onClick={onConfirm}
+            disabled={isPending}
+            className={destructive ? 'bg-red-500 hover:bg-red-600 text-white' : undefined}
+          >
+            {isPending ? '처리 중...' : confirmText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/shared/ui/modal/index.ts
+++ b/apps/frontend/src/shared/ui/modal/index.ts
@@ -1,3 +1,4 @@
 export { default as ReportModal } from './ReportModal';
 export { default as LoginRequiredModal } from './LoginRequiredModal';
 export { default as MemberProfileModal } from './MemberProfileModal';
+export { default as ConfirmModal } from './ConfirmModal';


### PR DESCRIPTION
- 백엔드: PATCH/DELETE /post/feed/:postId, PATCH /comments/:commentId (작성자 본인만)
- FeedPostResponseDto에 updatedAt 노출
- 프런트: FeedCard 케밥(⋯) 메뉴 + "수정됨" 배지, /feed/[id]/edit 페이지
- 게시글 삭제 확인 모달, 댓글 인라인 수정 UI

# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## ✈️ 관련 이슈

<!-- 닫고자 하는 이슈 번호를 아래에 적어주세요. 예: close #(이슈번호) -->

## 📋 작업 내용

<!-- 수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요. -->

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다. -->

## 📄 기타

<!-- 추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요. -->
