### PR TITLE
Feat(#110): azure 클라우드로의 이전을 위해 설정을 변경한다.

### DIFF
--- a/.github/workflows/deploy-aws-ec2.yml
+++ b/.github/workflows/deploy-aws-ec2.yml
@@ -1,7 +1,17 @@
-name: Backend CI/CD (AWS EC2)
+name: Backend CI/CD
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'apps/backend/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+  pull_request:
     branches:
       - main
     paths:
@@ -51,7 +61,7 @@ jobs:
         run: pnpm turbo run build --filter=@homerunnie/backend...
 
   deploy:
-    name: Deploy to EC2
+    name: Deploy to Server
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
@@ -61,28 +71,22 @@ jobs:
           submodules: true
           token: ${{ secrets.PRIVATE_SUBMODULE_TOKEN }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Build, tag, and push image to Docker Hub
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f apps/backend/Dockerfile .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker build -t $DOCKERHUB_REPOSITORY:$IMAGE_TAG -t $DOCKERHUB_REPOSITORY:latest -f apps/backend/Dockerfile .
+          docker push $DOCKERHUB_REPOSITORY:$IMAGE_TAG
+          docker push $DOCKERHUB_REPOSITORY:latest
 
-      - name: Copy .env to EC2
+      - name: Copy .env to Server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -92,36 +96,29 @@ jobs:
           target: '~/jikgwan'
           strip_components: 3
 
-      - name: Get ECR Login Password
-        id: ecr-pass
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          echo "password=$(aws ecr get-login-password --region $AWS_REGION)" >> $GITHUB_OUTPUT
-
-      - name: Deploy to EC2
+      - name: Deploy to Server
         uses: appleboy/ssh-action@master
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          ECR_PASSWORD: ${{ steps.ecr-pass.outputs.password }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: ECR_REGISTRY,ECR_REPOSITORY,ECR_PASSWORD,IMAGE_TAG
+          envs: DOCKERHUB_USERNAME,DOCKERHUB_TOKEN,DOCKERHUB_REPOSITORY,IMAGE_TAG
           script: |
             set -e
             mkdir -p ~/jikgwan
             cd ~/jikgwan
 
-            echo "$ECR_PASSWORD" | docker login --username AWS --password-stdin $ECR_REGISTRY
+            echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
             cat <<EOF > docker-compose.prod.yaml
             services:
               backend:
-                image: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+                image: $DOCKERHUB_REPOSITORY:$IMAGE_TAG
                 container_name: jikgwan-backend
                 ports:
                   - "3030:3030"
@@ -131,7 +128,7 @@ jobs:
                   - CI=true
                 restart: always
             EOF
-          
+
             docker compose -f docker-compose.prod.yaml pull
             docker compose -f docker-compose.prod.yaml run -T --rm backend node dist/scripts/migrate.js
             docker compose -f docker-compose.prod.yaml up -d

--- a/.github/workflows/deploy-aws-ec2.yml
+++ b/.github/workflows/deploy-aws-ec2.yml
@@ -11,16 +11,6 @@ on:
       - 'package.json'
       - 'pnpm-workspace.yaml'
       - 'turbo.json'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/**'
-      - 'apps/backend/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'pnpm-workspace.yaml'
-      - 'turbo.json'
 
 jobs:
   build-and-test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+이 프로젝트는 야구 팬들을 위한 소셜 플랫폼 "Homerunnie"의 모노레포입니다. pnpm workspace와 Turbo를 사용하여 Frontend(Next.js)와 Backend(NestJS)를 관리합니다.
+
+## Monorepo Structure
+
+```
+homerunnie/
+├── apps/
+│   ├── frontend/          # Next.js 14 + TypeScript
+│   └── backend/           # NestJS + Drizzle ORM + PostgreSQL
+└── packages/
+    └── shared/            # 공유 타입 및 유틸리티
+```
+
+## Common Commands
+
+### Development
+
+```bash
+# 전체 개발 서버 실행 (TUI 모드)
+pnpm dev
+
+# 전체 개발 서버 실행 (Stream 모드)
+pnpm dev:stream
+
+# Frontend만 실행
+pnpm --filter @homerunnie/frontend dev
+
+# Backend만 실행
+pnpm --filter @homerunnie/backend dev
+```
+
+### Build & Test
+
+```bash
+# 전체 빌드
+pnpm build
+
+# Lint 실행
+pnpm lint
+
+# 타입 체크
+pnpm type-check
+
+# 테스트 실행
+pnpm test
+
+# 테스트 (watch 모드)
+pnpm test:watch
+
+# 테스트 커버리지
+pnpm test:cov
+```
+
+### Database (Backend)
+
+```bash
+# Drizzle 스키마를 DB에 푸시
+pnpm --filter @homerunnie/backend db:push
+
+# 마이그레이션 파일 생성
+pnpm --filter @homerunnie/backend db:generate
+
+# 마이그레이션 실행
+pnpm --filter @homerunnie/backend db:migrate
+
+# DB 초기화 (드롭 + 푸시)
+pnpm --filter @homerunnie/backend db:reset
+
+# DB 클리어
+pnpm --filter @homerunnie/backend db:clear
+
+# 시드 데이터 삽입
+pnpm --filter @homerunnie/backend db:seed
+
+# DB 완전 초기화 (클리어 + 시드)
+pnpm --filter @homerunnie/backend db:fresh
+```
+
+### Frontend Specific
+
+```bash
+# Storybook 실행
+pnpm --filter @homerunnie/frontend storybook
+
+# Storybook 빌드
+pnpm --filter @homerunnie/frontend build-storybook
+```
+
+## Frontend
+
+- **Framework**: Next.js 14 (App Router)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS v4
+- **UI Library**: shadcn/ui, Radix UI
+- **State Management**: TanStack Query
+- **Testing**: Jest + Vitest
+- **Documentation**: Storybook
+
+## Backend Architecture (NestJS)
+
+### Module Structure
+
+Backend는 도메인별로 모듈화되어 있습니다:
+
+- **`auth/`**: 인증 (Kakao OAuth, JWT)
+- **`member/`**: 회원 관리
+- **`post/`**: 게시글
+- **`comment/`**: 댓글
+- **`participation/`**: 참여 관리
+- **`scrap/`**: 스크랩
+- **`report/`**: 신고
+- **`warn/`**: 경고
+- **`chat/`**: 실시간 채팅 (Socket.IO Gateway)
+- **`admin/`**: 관리자 기능
+- **`common/`**: 공통 기능
+  - `db/`: Drizzle ORM 설정, 엔티티, enums
+  - `decorators/`: 커스텀 데코레이터 (CurrentMember, Roles 등)
+  - `guards/`: 가드 (RolesGuard 등)
+  - `interceptors/`: 인터셉터 (LoggingInterceptor)
+  - `filters/`: 예외 필터 (HttpExceptionFilter)
+  - `dto/`: 공통 DTO (페이지네이션, 응답 등)
+
+### Database (Drizzle ORM)
+
+- **ORM**: Drizzle ORM
+- **DB**: PostgreSQL
+- **Schema 위치**: 각 도메인 모듈의 `domain/` 폴더
+- **Schema Export**: `common/db/schema/index.ts`에서 모든 엔티티를 export해야 Drizzle이 인식합니다.
+
+**새 엔티티 추가 시**:
+
+1. 도메인 모듈에 `domain/` 폴더 생성
+2. 엔티티 정의 (Drizzle 스키마)
+3. `common/db/schema/index.ts`에 export 추가
+
+### Authentication
+
+- Passport 전략 사용 (Kakao OAuth)
+- JWT 토큰 기반 인증
+- `@CurrentMember()` 데코레이터로 현재 사용자 정보 주입
+- `@Roles()` 데코레이터와 RolesGuard로 권한 관리
+
+### WebSocket (Chat)
+
+- Socket.IO 사용
+- `chat/chat.gateway.ts`에서 실시간 채팅 처리
+- 단톡방 형태로 구현됨
+
+## Git Workflow
+
+- **Main Branch**: `main` (브랜치명이 비어있으므로 main 사용 추정)
+- **Current Branch**: `feat/chat-24`
+- **브랜치 네이밍**: `feat/`, `fix/`, `style/` 등 prefix 사용
+- **커밋 컨벤션**: 한글 커밋 메시지 사용 (예: `feat: 단일채팅방 -> 단톡방으로 기능 변화`)
+
+## Package Manager
+
+**pnpm**을 사용합니다 (v10.16.0). npm이나 yarn 대신 pnpm 사용을 권장합니다.
+
+## Environment Variables
+
+- Frontend: `.env.local` (루트)
+- Backend: `apps/backend/secret/.env`, `apps/backend/secret/.env.postgresql`
+
+환경 변수 파일은 Git에서 무시되므로 로컬에서 직접 설정해야 합니다.
+
+## Testing
+
+- Frontend: Jest + Vitest (Storybook 통합)
+- Backend: Jest
+
+단일 테스트 파일 실행:
+
+```bash
+# Frontend
+pnpm --filter @homerunnie/frontend test [파일경로]
+
+# Backend
+pnpm --filter @homerunnie/backend test [파일경로]
+```
+
+## Important Notes
+
+1. **DB 스키마 변경**: 반드시 `common/db/schema/index.ts`에 export 추가
+2. **타입 안정성**: TypeScript strict 모드 사용, 타입 체크 필수
+3. **린트**: 코드 작성 후 `pnpm lint` 실행 권장

--- a/apps/backend/src/common/config/drizzle.config.ts
+++ b/apps/backend/src/common/config/drizzle.config.ts
@@ -6,16 +6,36 @@ import * as path from 'path';
 const envFile = process.env.NODE_ENV === 'production' ? 'prod.env' : '.env';
 config({ path: path.resolve(__dirname, `../../../secret/${envFile}`) });
 
+const databaseUrl = process.env.DATABASE_URL;
+const useSsl =
+  process.env.NODE_ENV === 'production' ||
+  process.env.DB_SSL === 'true' ||
+  databaseUrl?.includes('supabase.co') ||
+  databaseUrl?.includes('pooler.supabase.com');
+const databaseUrlWithSsl = (() => {
+  if (!databaseUrl || !useSsl) return databaseUrl;
+
+  const url = new URL(databaseUrl);
+  if (!url.searchParams.has('sslmode')) {
+    url.searchParams.set('sslmode', 'require');
+  }
+  return url.toString();
+})();
+
 export default {
   schema: './src/**/*.entity.ts',
   out: './drizzle/migrations',
   dialect: 'postgresql',
-  dbCredentials: {
-    host: process.env.DB_HOST ?? 'localhost',
-    port: parseInt(process.env.DB_PORT ?? '5432', 10),
-    user: process.env.DB_USERNAME ?? '',
-    password: String(process.env.DB_PASSWORD ?? ''),
-    database: process.env.DB_NAME ?? '',
-    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : (false as any),
-  },
+  dbCredentials: databaseUrl
+    ? {
+        url: databaseUrlWithSsl ?? databaseUrl,
+      }
+    : {
+        host: process.env.DB_HOST ?? 'localhost',
+        port: parseInt(process.env.DB_PORT ?? '5432', 10),
+        user: process.env.DB_USERNAME ?? '',
+        password: String(process.env.DB_PASSWORD ?? ''),
+        database: process.env.DB_NAME ?? '',
+        ssl: useSsl ? { rejectUnauthorized: false } : (false as any),
+      },
 } satisfies Config;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- [ ] 기능 추가
- [ ] 기능 제거
- [ ] 버그 수정
- [x] 스타일/로직
- [x] 기존 환경 변경 및 빌드 관련 코드 업데이트
- [ ] 기타

## 연관 이슈

<!-- close #이슈번호 -->
#110 

## 작업 내용

- AWS ECR 기반 이미지 배포 방식을 Docker Hub 기반으로 변경했습니다.
- GitHub Actions에서 Docker Hub 로그인 후 백엔드 이미지를 빌드하고, `${{ github.sha }}` 및 `latest` 태그로 push하도록 수정했습니다.
- 배포 서버에서도 Docker Hub에 로그인한 뒤 Docker Compose로 이미지를 pull하도록 변경했습니다.
- ECR 로그인, AWS credentials 설정, ECR password 발급 단계를 제거했습니다.
- 배포 대상이 EC2에 고정되지 않도록 workflow/job/step 이름 일부를 `Server` 기준으로 정리했습니다.
- Supabase DB 연결을 위해 Drizzle 설정이 `DATABASE_URL`을 우선 사용하도록 변경했습니다.
- Supabase/운영 환경에서는 `sslmode=require`가 적용되도록 처리했습니다.

## 스크린샷 (선택 사항)

<!-- 배포/워크플로우 변경이라 화면 스크린샷 없음 -->

## 기타

### 필요한 GitHub Secrets

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`
- `DOCKERHUB_REPOSITORY`
- `EC2_HOST` 또는 Azure VM 호스트 값
- `EC2_USER` 또는 Azure VM 접속 유저
- `EC2_SSH_KEY`

### 필요한 운영 환경 변수

`prod.env`의 `DATABASE_URL`을 Supabase Postgres 연결 문자열로 설정해야 합니다.

예시:

```env
DATABASE_URL=postgresql://postgres.<project-ref>:<DB_PASSWORD>@aws-0<region>.pooler.supabase.com:6543/postgres?sslmode=require
```